### PR TITLE
Preparing LimeSurvey API update

### DIFF
--- a/UrlTemplateChanger.php
+++ b/UrlTemplateChanger.php
@@ -36,9 +36,7 @@ class UrlTemplateChanger extends \ls\pluginmanager\PluginBase {
         )
     );
 
-    public function __construct(PluginManager $manager, $id) {
-        parent::__construct($manager, $id);
-
+    public function init() {
         $this->subscribe('afterFindSurvey');
         $this->subscribe('beforeSurveySettings');
         $this->subscribe('newSurveySettings');


### PR DESCRIPTION
In 2.63.0 : there are an update of the API, i have a lot of my plugins broken.

See https://www.limesurvey.org/forum/plugins/108432-preparing-plugin-for-api-update

init() is OK in 2.6 and surely in develop